### PR TITLE
Added option to stream GCC inputs to a binary file

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -323,6 +323,7 @@ void SConfig::SaveInputSettings(IniFile& ini)
   IniFile::Section* input = ini.GetOrCreateSection("Input");
 
   input->Set("BackgroundInput", m_BackgroundInput);
+  input->Set("WriteInputsToFile", m_WriteInputsToFile);
 }
 
 void SConfig::SaveFifoPlayerSettings(IniFile& ini)
@@ -630,6 +631,7 @@ void SConfig::LoadInputSettings(IniFile& ini)
   IniFile::Section* input = ini.GetOrCreateSection("Input");
 
   input->Get("BackgroundInput", &m_BackgroundInput, false);
+  input->Get("WriteInputsToFile", &m_WriteInputsToFile, false);
 }
 
 void SConfig::LoadFifoPlayerSettings(IniFile& ini)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -320,6 +320,7 @@ struct SConfig
 
   // Input settings
   bool m_BackgroundInput;
+  bool m_WriteInputsToFile;
   bool m_AdapterRumble[4];
   bool m_AdapterKonga[4];
 

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -228,6 +228,11 @@ void ControllerConfigDiag::OnBackgroundInputChanged(wxCommandEvent& event)
   SConfig::GetInstance().m_BackgroundInput = event.IsChecked();
 }
 
+void ControllerConfigDiag::OnWriteInputsToFileChanged(wxCommandEvent& event)
+{
+  SConfig::GetInstance().m_WriteInputsToFile = event.IsChecked();
+}
+
 wxSizer* ControllerConfigDiag::CreateAdvancedSettingsSizer()
 {
   const int space5 = FromDIP(5);
@@ -237,8 +242,15 @@ wxSizer* ControllerConfigDiag::CreateAdvancedSettingsSizer()
   m_background_input_checkbox->Bind(wxEVT_CHECKBOX, &ControllerConfigDiag::OnBackgroundInputChanged,
     this);
 
+  m_write_inputs_to_file_checkbox = new wxCheckBox(this, wxID_ANY, _("Write Gamecube Controller Inputs To File"));
+  m_write_inputs_to_file_checkbox->SetValue(SConfig::GetInstance().m_WriteInputsToFile);
+  m_write_inputs_to_file_checkbox->Bind(wxEVT_CHECKBOX, &ControllerConfigDiag::OnWriteInputsToFileChanged, this);
+
+
   auto* const box = new wxStaticBoxSizer(wxVERTICAL, this, _("Advanced Settings"));
   box->Add(m_background_input_checkbox, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+  box->AddSpacer(space5);
+  box->Add(m_write_inputs_to_file_checkbox, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
   return box;
 }
 

--- a/Source/Core/DolphinWX/ControllerConfigDiag.h
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.h
@@ -51,6 +51,7 @@ private:
   void OnEnableSpeaker(wxCommandEvent& event);
 
   void OnBackgroundInputChanged(wxCommandEvent& event);
+  void OnWriteInputsToFileChanged(wxCommandEvent& event);
 
   std::map<wxWindowID, unsigned int> m_gc_port_from_choice_id;
   std::map<wxWindowID, unsigned int> m_gc_port_from_config_id;
@@ -78,4 +79,5 @@ private:
   wxCheckBox* m_enable_speaker_data;
 
   wxCheckBox* m_background_input_checkbox;
+  wxCheckBox* m_write_inputs_to_file_checkbox;
 };

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -3,11 +3,13 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <fstream>
 #include <libusb.h>
 #include <mutex>
 
 #include "Common/Event.h"
 #include "Common/Flag.h"
+#include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/Thread.h"
 #include "Core/ConfigManager.h"
@@ -69,6 +71,8 @@ namespace GCAdapter
   static u8 s_endpoint_out = 0;
 
   static u64 s_last_init = 0;
+
+  static auto lastPollTime = std::chrono::steady_clock::now();
 
   static void Read()
   {
@@ -395,6 +399,12 @@ namespace GCAdapter
     NOTICE_LOG(SERIALINTERFACE, "GC Adapter detached");
   }
 
+  void writeInputsToFile(char* payload) {
+    std::ofstream myfile;
+    myfile.open("./GCCinputs.bin", std::ios::binary);
+    myfile.write(payload, 37);
+  }
+
   GCPadStatus Input(int chan)
   {
     if (!UseAdapter())
@@ -439,6 +449,16 @@ namespace GCAdapter
       {
         u8 b1 = controller_payload_copy[1 + (9 * chan) + 1];
         u8 b2 = controller_payload_copy[1 + (9 * chan) + 2];
+
+        if (SConfig::GetInstance().m_WriteInputsToFile == true)
+        {
+          auto now = std::chrono::steady_clock::now();
+          if (std::chrono::duration_cast<std::chrono::microseconds>(now - lastPollTime).count() >= 16667)
+          {
+            writeInputsToFile((char*) controller_payload_copy);
+            lastPollTime = std::chrono::steady_clock::now();
+          }
+        }
 
         if (b1 & (1 << 0))
           pad.button |= PAD_BUTTON_A;


### PR DESCRIPTION
New configuration option added to Controllers -> Advanced Settings: **Write Gamecube Inputs To File**

Setting this option to true will stream the binary data Dolphin receives from libusb to a binary file called GCCinputs.bin at 60Hz. The file is continuously overwritten with the polled inputs. Other programs can then read from this file for uses such as visual input displays.

Probably not the most performance-friendly way of doing this, but it's straightforward and simple for other programs to read from.